### PR TITLE
git_vivado.py: set OS agnostic path to config file

### DIFF
--- a/git_vivado.py
+++ b/git_vivado.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
 	script_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
 	project_name = os.path.basename(os.path.abspath(os.path.join(script_dir, '..')))
 	config = configparser.ConfigParser()
-	config.read("%s\config.ini" % script_dir)
+	config.read(os.path.join(script_dir, "config.ini"))
 	operating_system = platform.system()
 	config_settings = config[operating_system]
 	


### PR DESCRIPTION
This script will only work properly on Linux if the paths use the
correct directory separator. By using os.path.join we do not need
to guess or check which slash to use, but instead we let python
decide.

Signed-off-by: Stephano Cetola <stephanoc@gmail.com>