### PR TITLE
Added support for capturing customized settings for Synthesis and Implementation and a small bugfix

### DIFF
--- a/digilent_vivado_checkin.tcl
+++ b/digilent_vivado_checkin.tcl
@@ -183,13 +183,30 @@ if {[file exists $repo_path/project_info.tcl] == 0 || $force_overwrite_info_scri
     set default_lib [get_property default_lib $proj_obj]
     set simulator_language [get_property simulator_language $proj_obj]
     set target_language [get_property target_language $proj_obj]
-    
+    set directives "#Custom directives for synthesis and implementation"
+
+	#Fetch non-default synthesis and implementation settings
+	foreach prop [list_property [get_runs synth_1] STEPS.*.ARGS.*] {
+		set Dval [list_property_value -default $prop [get_runs synth_1]]
+		set val [get_property $prop [get_runs synth_1]]
+		if {$Dval!=$val} {
+			append directives "\n\tset_property " $prop " " $val " [get_runs synth_1]"
+    }}
+
+	foreach prop [list_property [get_runs impl_1] STEPS.*.ARGS.*] {
+		set Dval [list_property_value -default $prop [get_runs impl_1]]
+		set val [get_property $prop [get_runs impl_1]]
+		if {$Dval!=$val} {
+			append directives "\n\tset_property " $prop " " $val " [get_runs impl_1]"
+    }}
+
     puts "INFO: Checking in project_info.tcl to version control."
     
     set var_map [list <part> $part                             \
                       <default_lib> $default_lib               \
                       <simulator_language> $simulator_language \
                       <target_language> $target_language       \
+                      <directives> $directives \
     ]
     
     if {$board_part ne ""} {

--- a/digilent_vivado_checkin.tcl
+++ b/digilent_vivado_checkin.tcl
@@ -190,14 +190,14 @@ if {[file exists $repo_path/project_info.tcl] == 0 || $force_overwrite_info_scri
 		set Dval [list_property_value -default $prop [get_runs synth_1]]
 		set val [get_property $prop [get_runs synth_1]]
 		if {$Dval!=$val} {
-			append directives "\n\tset_property " $prop " " $val " [get_runs synth_1]"
+			append directives "\n\tset_property " $prop " " $val " \[get_runs synth_1\]"
     }}
 
 	foreach prop [list_property [get_runs impl_1] STEPS.*.ARGS.*] {
 		set Dval [list_property_value -default $prop [get_runs impl_1]]
 		set val [get_property $prop [get_runs impl_1]]
 		if {$Dval!=$val} {
-			append directives "\n\tset_property " $prop " " $val " [get_runs impl_1]"
+			append directives "\n\tset_property " $prop " " $val " \[get_runs impl_1\]"
     }}
 
     puts "INFO: Checking in project_info.tcl to version control."

--- a/digilent_vivado_checkin.tcl
+++ b/digilent_vivado_checkin.tcl
@@ -102,7 +102,7 @@ foreach f $required_files {
 
 # Save source files, including block design tcl script
 # WARNING: This script does not capture any non-xdc files for block-design projects
-set bd_files [get_files -of_objects [get_filesets sources_1] -filter "NAME=~*.bd"]
+set bd_files [get_files -of_objects [get_filesets sources_1] -filter "NAME=~*.bd && NAME!~*/bd/*/ip/*"]
 if {[llength $bd_files] > 1} {
     puts "ERROR: This script cannot handle projects containing more than one block design!"
 } elseif {[llength $bd_files] == 1} {

--- a/digilent_vivado_checkout.tcl
+++ b/digilent_vivado_checkout.tcl
@@ -168,9 +168,6 @@ if {[string equal [get_runs -quiet synth_1] ""]} {
 puts "INFO: Configuring synth_1 run"
 set obj [get_runs synth_1]
 set_property "part" $part_name $obj
-set_property "steps.synth_design.args.flatten_hierarchy" "none" $obj
-set_property "steps.synth_design.args.directive" "RuntimeOptimized" $obj
-set_property "steps.synth_design.args.fsm_extraction" "off" $obj
 
 # Set the current synth run
 puts "INFO: Setting current synthesis run"
@@ -187,9 +184,6 @@ if {[string equal [get_runs -quiet impl_1] ""]} {
 puts "INFO: Configuring impl_1 run"
 set obj [get_runs impl_1]
 set_property "part" $part_name $obj
-set_property "steps.opt_design.args.directive" "RuntimeOptimized" $obj
-set_property "steps.place_design.args.directive" "RuntimeOptimized" $obj
-set_property "steps.route_design.args.directive" "RuntimeOptimized" $obj
 
 # Set the current impl run
 puts "INFO: Setting current implementation run"

--- a/templates/project_info.tcl
+++ b/templates/project_info.tcl
@@ -15,5 +15,5 @@ proc set_project_properties_pre_add_repo {proj_name} {
 
 proc set_project_properties_post_create_runs {proj_name} {
     set project_obj [get_projects $proj_name]
-    # default nothing
+	<directives>
 }


### PR DESCRIPTION
This pull request adds support for capturing synthesis and implementation settings that differ from Vivado defaults and fixed support for Block Designs with IPs that create their own BD such as Xilinx's MIPI CSI-2 Rx Subsystem.